### PR TITLE
Add bcrypt to admin password into UsersSeedTable

### DIFF
--- a/src/Starter/database/seeds/UserTableSeeder.php
+++ b/src/Starter/database/seeds/UserTableSeeder.php
@@ -17,7 +17,7 @@ class UserTableSeeder extends Seeder
 
         $user = User::create([
             'email' => 'admin@admin.com',
-            'password' => 'admin',
+            'password' => bcrypt('admin'),
         ]);
 
         $service->create($user, 'admin', 'admin', false);


### PR DESCRIPTION
Fix the default login provided by Laracogs, if you try login with admin@admin.com and with "admin" won't work.