### PR TITLE
Use model namespace when referring to models

### DIFF
--- a/src/Templates/Repository/Repository.txt
+++ b/src/Templates/Repository/Repository.txt
@@ -2,7 +2,7 @@
 
 namespace _namespace_repository_;
 
-use _namespace_repository_\_camel_case_;
+use _namespace_model_\_camel_case_;
 use Illuminate\Support\Facades\Schema;
 
 class _camel_case_Repository

--- a/src/Templates/Request.txt
+++ b/src/Templates/Request.txt
@@ -4,7 +4,7 @@ namespace _namespace_request_;
 
 use Auth;
 use _app_namespace_Http\Requests\Request;
-use _namespace_repository_\_camel_case_;
+use _namespace_model_\_camel_case_;
 
 class _camel_case_Request extends Request
 {


### PR DESCRIPTION
Currently the default templates will not work when models are not in the same namespace as the repository. Fixed the templates to let them use the model namespace, instead of repository namespace, when referring to a model.