### PR TITLE
WIP: Add migration path to config

### DIFF
--- a/src/Console/Crud.php
+++ b/src/Console/Crud.php
@@ -108,6 +108,7 @@ class Crud extends Command
             '_path_request_'             => app_path('Http/Requests/'),
             '_path_routes_'              => app_path('Http/routes.php'),
             '_path_api_routes_'          => app_path('Http/api-routes.php'),
+            '_path_migrations_'          => base_path('database/migrations'),
             'routes_prefix'              => '',
             'routes_suffix'              => '',
             '_app_namespace_'            => $this->getAppNamespace(),
@@ -193,7 +194,7 @@ class Crud extends Command
             $this->generateAPI($crudGenerator, $config, $bar);
             $bar->advance();
 
-            $this->generateDB($dbGenerator, $bar, $section, $table, $splitTable);
+            $this->generateDB($dbGenerator, $config, $bar, $section, $table, $splitTable);
             $bar->finish();
 
             $this->crudReport($table);
@@ -230,6 +231,7 @@ class Crud extends Command
             '_path_request_'             => app_path('Http/Requests/'.ucfirst($section)),
             '_path_routes_'              => app_path('Http/routes.php'),
             '_path_api_routes_'          => app_path('Http/api-routes.php'),
+            '_path_migrations_'          => base_path('database/migrations'),
             'routes_prefix'              => "\n\nRoute::group(['namespace' => '".ucfirst($section)."', 'prefix' => '".strtolower($section)."', 'middleware' => ['web']], function () { \n",
             'routes_suffix'              => "\n});",
             '_app_namespace_'            => $this->getAppNamespace(),
@@ -345,12 +347,12 @@ class Crud extends Command
      *
      * @return void
      */
-    private function generateDB($dbGenerator, $bar, $section, $table, $splitTable)
+    private function generateDB($dbGenerator, $config, $bar, $section, $table, $splitTable)
     {
         if ($this->option('migration')) {
-            $dbGenerator->createMigration($section, $table, $splitTable);
+            $dbGenerator->createMigration($config, $section, $table, $splitTable);
             if ($this->option('schema')) {
-                $dbGenerator->createSchema($section, $table, $splitTable, $this->option('schema'));
+                $dbGenerator->createSchema($config, $section, $table, $splitTable, $this->option('schema'));
             }
         }
         $bar->advance();

--- a/src/Generators/DatabaseGenerator.php
+++ b/src/Generators/DatabaseGenerator.php
@@ -27,7 +27,7 @@ class DatabaseGenerator
      *
      * @return void
      */
-    public function createMigration($section, $table, $splitTable)
+    public function createMigration($config, $section, $table, $splitTable)
     {
         try {
             if (!empty($section)) {
@@ -42,6 +42,7 @@ class DatabaseGenerator
                 'name'     => $migrationName,
                 '--table'  => $tableName,
                 '--create' => true,
+                '--path'   => $this->getMigrationsPath($config, true),
             ]);
         } catch (Exception $e) {
             throw new Exception('Could not create the migration', 1);
@@ -57,9 +58,9 @@ class DatabaseGenerator
      *
      * @return void
      */
-    public function createSchema($section, $table, $splitTable, $schema)
+    public function createSchema($config, $section, $table, $splitTable, $schema)
     {
-        $migrationFiles = $this->filesystem->allFiles(base_path('database/migrations'));
+        $migrationFiles = $this->filesystem->allFiles($this->getMigrationsPath($config));
 
         if (!empty($section)) {
             $migrationName = 'create_'.str_plural(strtolower(implode('_', $splitTable))).'_table';
@@ -85,5 +86,18 @@ class DatabaseGenerator
                 file_put_contents($file->getPathname(), $migrationData);
             }
         }
+    }
+
+    private function getMigrationsPath($config, $relative = false)
+    {
+        if (!is_dir($config['_path_migrations_'])) {
+            mkdir($config['_path_migrations_'], 0777, true);
+        }
+
+        if ($relative) {
+            return str_replace(base_path(), '', $config['_path_migrations_']);
+        }
+
+        return $config['_path_migrations_'];
     }
 }


### PR DESCRIPTION
To make it possible to have your migrations in an alternative directory, the migration path is now available in the config. Still defaults to `database/migrations`.