### PR TITLE
Improve readability of tests

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class AppTest extends Orchestra\Testbench\TestCase
 {
     protected $app;

--- a/tests/CrudGeneratorTest.php
+++ b/tests/CrudGeneratorTest.php
@@ -52,57 +52,67 @@ class CrudGeneratorTest extends PHPUnit_Framework_TestCase
     public function testApiGenerator()
     {
         $this->crud = vfsStream::setup("Http/Controllers/Api");
+
         $this->generator->createApi($this->config, false);
-        $this->assertTrue($this->crud->hasChild('Http/Controllers/Api/TestTableController.php'));
         $contents = $this->crud->getChild('Http/Controllers/Api/TestTableController.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableController extends Controller') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Http/Controllers/Api/TestTableController.php'));
+        $this->assertContains('class TestTableController extends Controller', $contents->getContent());
     }
 
     public function testControllerGenerator()
     {
         $this->crud = vfsStream::setup("Http/Controllers");
         $this->generator->createController($this->config);
+
         $this->assertTrue($this->crud->hasChild('Http/Controllers/TestTableController.php'));
         $contents = $this->crud->getChild('Http/Controllers/TestTableController.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableController extends Controller') !== false);
+
+        $this->assertContains('class TestTableController extends Controller', $contents->getContent());
     }
 
     public function testRepositoryGenerator()
     {
         $this->crud = vfsStream::setup("Repositories/TestTable");
+
         $this->generator->createRepository($this->config);
-        $this->assertTrue($this->crud->hasChild('Repositories/TestTable/TestTableRepository.php'));
         $contents = $this->crud->getChild('Repositories/TestTable/TestTableRepository.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRepository') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Repositories/TestTable/TestTableRepository.php'));
+        $this->assertContains('class TestTableRepository', $contents->getContent());
     }
 
     public function testRequestGenerator()
     {
         $this->crud = vfsStream::setup("Http/Requests");
+
         $this->generator->createRequest($this->config);
-        $this->assertTrue($this->crud->hasChild('Http/Requests/TestTableRequest.php'));
         $contents = $this->crud->getChild('Http/Requests/TestTableRequest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRequest') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Http/Requests/TestTableRequest.php'));
+        $this->assertContains('class TestTableRequest', $contents->getContent());
     }
 
     public function testServiceGenerator()
     {
         $this->crud = vfsStream::setup("Services");
+
         $this->generator->createService($this->config);
-        $this->assertTrue($this->crud->hasChild('Services/TestTableService.php'));
         $contents = $this->crud->getChild('Services/TestTableService.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableService') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Services/TestTableService.php'));
+        $this->assertContains('class TestTableService', $contents->getContent());
     }
 
     public function testRoutesGenerator()
     {
         $this->crud = vfsStream::setup("Http");
         file_put_contents(vfsStream::url('Http/routes.php'), 'test');
+
         $this->generator->createRoutes($this->config, false);
         $contents = $this->crud->getChild('Http/routes.php');
-        $this->assertTrue(strpos($contents->getContent(), 'TestTableController') !== false);
 
-        // Ensure Search Route specification exists and Controller and Action remain
+        $this->assertContains('TestTableController', $contents->getContent());
         $this->assertContains('\'as\' => \'testtables.search\'', $contents->getContent());
         $this->assertContains('\'uses\' => \'TestTableController@search\'', $contents->getContent());
     }
@@ -110,43 +120,47 @@ class CrudGeneratorTest extends PHPUnit_Framework_TestCase
     public function testViewsGenerator()
     {
         $this->crud = vfsStream::setup("resources/views");
+
         $this->generator->createViews($this->config);
-        $this->assertTrue($this->crud->hasChild('resources/views/testtables/index.blade.php'));
         $contents = $this->crud->getChild('resources/views/testtables/index.blade.php');
-        $this->assertTrue(strpos($contents->getContent(), '$testtable') !== false);
+
+        $this->assertTrue($this->crud->hasChild('resources/views/testtables/index.blade.php'));
+        $this->assertContains('$testtable', $contents->getContent());
     }
 
     public function testTestGenerator()
     {
         $this->crud = vfsStream::setup("tests");
+
         $this->assertTrue($this->generator->createTests($this->config, false));
 
-        $this->assertTrue($this->crud->hasChild('tests/acceptance/TestTableAcceptanceTest.php'));
         $contents = $this->crud->getChild('tests/acceptance/TestTableAcceptanceTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableAcceptanceTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/acceptance/TestTableAcceptanceTest.php'));
+        $this->assertContains('class TestTableAcceptanceTest', $contents->getContent());
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableRepositoryIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRepositoryIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
+        $this->assertContains('class TestTableRepositoryIntegrationTest', $contents->getContent());
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableServiceIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableServiceIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
+        $this->assertContains('class TestTableServiceIntegrationTest', $contents->getContent());
     }
 
     public function testTestGeneratorServiceOnly()
     {
         $this->crud = vfsStream::setup("tests");
+
         $this->assertTrue($this->generator->createTests($this->config, true));
 
         $this->assertFalse($this->crud->hasChild('tests/acceptance/TestTableAcceptanceTest.php'));
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableRepositoryIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRepositoryIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
+        $this->assertContains('class TestTableRepositoryIntegrationTest', $contents->getContent());
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableServiceIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableServiceIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
+        $this->assertContains('class TestTableServiceIntegrationTest', $contents->getContent());
     }
 }

--- a/tests/CrudServiceTest.php
+++ b/tests/CrudServiceTest.php
@@ -47,21 +47,23 @@ class CrudServiceTest extends PHPUnit_Framework_TestCase
     public function testPrepareTableDefinition()
     {
         $table = "id:increments,name:string,details:text";
+
         $result = $this->service->prepareTableDefinition($table);
 
-        $this->assertTrue((bool) strstr($result, 'id'));
-        $this->assertTrue((bool) strstr($result, 'name'));
-        $this->assertTrue((bool) strstr($result, 'details'));
+        $this->assertContains('id', $result);
+        $this->assertContains('name', $result);
+        $this->assertContains('details', $result);
     }
 
     public function testPrepareTableExample()
     {
         $table = "id:increments,name:string,details:text,created_on:dateTime";
+
         $result = $this->service->prepareTableExample($table);
 
-        $this->assertTrue((bool) strstr($result, 'laravel'));
-        $this->assertTrue((bool) strstr($result, 'I am Batman'));
-        $this->assertTrue((bool) strstr($result, '1'));
+        $this->assertContains('laravel', $result);
+        $this->assertContains('I am Batman', $result);
+        $this->assertContains('1', $result);
     }
 
 }

--- a/tests/CrudValidatorTest.php
+++ b/tests/CrudValidatorTest.php
@@ -60,8 +60,8 @@ class CrudValidatorTest extends AppTest
             ->with('migration')
             ->andReturn(true)
             ->getMock();
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateSchema($this->command);
     }
 
@@ -78,6 +78,7 @@ class CrudValidatorTest extends AppTest
             ->andReturn(true);
 
         $test = $this->validator->validateSchema($this->command);
+
         $this->assertTrue($test);
     }
 
@@ -86,8 +87,8 @@ class CrudValidatorTest extends AppTest
         $this->command->shouldReceive('option')
             ->with('ui')
             ->andReturn('purecss');
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateSchema($this->command);
     }
 
@@ -107,6 +108,7 @@ class CrudValidatorTest extends AppTest
             ->andReturn(true);
 
         $test = $this->validator->validateOptions($this->command);
+
         $this->assertTrue($test);
     }
 
@@ -124,8 +126,8 @@ class CrudValidatorTest extends AppTest
         $this->command->shouldReceive('option')
             ->with('migration')
             ->andReturn(false);
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateOptions($this->command);
     }
 
@@ -143,8 +145,8 @@ class CrudValidatorTest extends AppTest
         $this->command->shouldReceive('option')
             ->with('migration')
             ->andReturn(false);
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateOptions($this->command);
     }
 }

--- a/tests/CryptoTest.php
+++ b/tests/CryptoTest.php
@@ -14,7 +14,9 @@ class CryptoTest extends PHPUnit_Framework_TestCase
     public function testEncode()
     {
         $enc = $this->encrypter->encrypt('js/card.sjs');
+
         $dec = $this->encrypter->decrypt($enc);
+
         $this->assertTrue(is_string($dec));
         $this->assertEquals($dec, 'js/card.sjs');
     }
@@ -22,6 +24,7 @@ class CryptoTest extends PHPUnit_Framework_TestCase
     public function testDecode()
     {
         $test = $this->encrypter->decrypt('YzllZTlhMTJkMGJhZGI2ZFF0TkkybnRFZWhnRFhGY2ZzMFFKRGc9PQ--');
+
         $this->assertTrue(is_string($test));
         $this->assertEquals($test, 'js/card.sjs');
     }
@@ -29,6 +32,7 @@ class CryptoTest extends PHPUnit_Framework_TestCase
     public function testUuid()
     {
         $test = $this->encrypter->uuid();
+
         $this->assertTrue(is_string($test));
         $this->assertEquals(strlen($test), 36);
         $this->assertContains('-', $test);

--- a/tests/DatabaseGeneratorTest.php
+++ b/tests/DatabaseGeneratorTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use org\bovigo\vfs\vfsStream;
-use Illuminate\Support\Facades\Artisan;
-use Illuminate\Container\Container as Container;
-use Illuminate\Support\Facades\Facade as Facade;
 use Yab\Laracogs\Generators\DatabaseGenerator;
 
 class DatabaseGeneratorTest extends AppTest
@@ -23,64 +19,62 @@ class DatabaseGeneratorTest extends AppTest
     public function testCreateMigrationFail()
     {
         $this->setExpectedException('Exception');
+
         $this->generator->createMigration('alskfdjbajlksbdfl', 'TestTable', 'lkdblkabflabsd');
     }
 
     public function testCreateMigrationSuccess()
     {
-        $this->generator->createMigration($this->config, '', 'TestTable', []);
-
-        $this->assertEquals(count(glob(base_path('database/migrations').'/*')), 1);
-
-        array_map('unlink', glob(base_path('database/migrations').'/*'));
-
-        $this->assertEquals(count(glob(base_path('database/migrations').'/*')), 0);
+        $this->createMigration();
     }
 
     public function testCreateMigrationSuccessAlternativeLocation()
     {
-        $config = [
-            '_path_migrations_' => base_path('alternative_migrations_location')
-        ];
-
-        $this->generator->createMigration($config, '', 'TestTable', []);
+        $this->createMigration('alternative_migrations_location');
 
         $this->assertCount(1, glob(base_path('alternative_migrations_location').'/*'));
-
-        array_map('unlink', glob(base_path('alternative_migrations_location').'/*'));
-
-        $this->assertCount(0, glob(base_path('alternative_migrations_location').'/*'));
     }
 
     public function testCreateSchema()
     {
-        $this->generator->createMigration($this->config, '', 'TestTable', []);
-        $migrations = glob(base_path('database/migrations').'/*');
-        $this->assertEquals(count($migrations), 1);
+        $migrations = $this->createMigration();
 
         $this->generator->createSchema($this->config, '', 'TestTable', [], 'id:increments,name:string');
 
-        $this->assertTrue(strpos(file_get_contents($migrations[0]), 'testtables') > 0);
-        $this->assertTrue(strpos(file_get_contents($migrations[0]), "table->increments('id')") > 0);
-
-        array_map('unlink', glob(base_path('database/migrations').'/*'));
+        $this->assertContains('testtables', file_get_contents($migrations[0]));
+        $this->assertContains('table->increments(\'id\')', file_get_contents($migrations[0]));
     }
 
     public function testCreateSchemaAlternativeLocation()
     {
-        $config = [
-            '_path_migrations_' => base_path('alternative_migrations_location')
-        ];
+        $migrations = $this->createMigration('alternative_migrations_location');
 
-        $this->generator->createMigration($config, '', 'TestTable', []);
-        $migrations = glob(base_path('alternative_migrations_location').'/*');
-        $this->assertCount(1, $migrations);
-
-        $this->generator->createSchema($config, '', 'TestTable', [], 'id:increments,name:string');
+        $this->generator->createSchema($this->config, '', 'TestTable', [], 'id:increments,name:string');
 
         $this->assertContains('testtables', file_get_contents($migrations[0]));
         $this->assertContains('table->increments(\'id\')', file_get_contents($migrations[0]));
+    }
 
-        array_map('unlink', glob(base_path('alternative_migrations_location').'/*'));
+    private function createMigration($location = null)
+    {
+        if ($location) {
+            $this->config = [
+                '_path_migrations_' => base_path($location)
+            ];
+        }
+
+        $this->generator->createMigration($this->config , '', 'TestTable', []);
+        $migrations = glob($this->config['_path_migrations_'].'/*');
+
+        $this->assertCount(1, $migrations);
+
+        return $migrations;
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        array_map('unlink', glob($this->config['_path_migrations_'] . '/*'));
     }
 }

--- a/tests/FormMakerTest.php
+++ b/tests/FormMakerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Container\Container as Container;
 use Illuminate\Support\Facades\Facade as Facade;
 use Yab\Laracogs\Utilities\FormMaker;
@@ -59,7 +58,7 @@ class FormMakerTest extends PHPUnit_Framework_TestCase
         $test = $this->formMaker->fromArray($testArray);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Number</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Number"></div>');
+        $this->assertEquals('<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Number</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Number"></div>', $test);
     }
 
     public function testFromArrayWithColumns()
@@ -72,18 +71,17 @@ class FormMakerTest extends PHPUnit_Framework_TestCase
         $test = $this->formMaker->fromArray($testArray, ['name']);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div>');
+        $this->assertEquals('<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div>', $test);
     }
 
     public function testFromObject()
     {
-        (object) $testObject = [
+        $testObject = [
             'attributes' => [
                 'name' => 'Joe',
                 'age' => 18,
             ],
         ];
-
         $columns = [
             'name' => [
                 'type' => 'string',
@@ -93,9 +91,9 @@ class FormMakerTest extends PHPUnit_Framework_TestCase
             ]
         ];
 
-        $test = $this->formMaker->fromObject($testObject, $columns);
+        $test = $this->formMaker->fromObject((object) $testObject, $columns);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Age</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Age"></div>');
+        $this->assertEquals('<div class="form-group "><label class="control-label" for="Name">Name</label><input  id="Name" class="form-control" type="text" name="name"    placeholder="Name"></div><div class="form-group "><label class="control-label" for="Age">Age</label><input  id="Age" class="form-control" type="number" name="age"    placeholder="Age"></div>', $test);
     }
 }

--- a/tests/HtmlGeneratorTest.php
+++ b/tests/HtmlGeneratorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Container\Container as Container;
 use Illuminate\Support\Facades\Facade as Facade;
 use Yab\Laracogs\Generators\HtmlGenerator;
@@ -32,7 +31,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         $test = $this->html->makeHidden(['name' => 'test'], 'test', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input  id="Test" name="test" type="hidden" value="test">');
+        $this->assertEquals('<input  id="Test" name="test" type="hidden" value="test">', $test);
     }
 
     public function testMakeText()
@@ -44,7 +43,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'simple-test', 'data-thing');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<textarea data-thing id="Test" class="form-control" name="test" placeholder="TestText">simple-test</textarea>');
+        $this->assertEquals('<textarea data-thing id="Test" class="form-control" name="test" placeholder="TestText">simple-test</textarea>', $test);
     }
 
     public function testMakeSelected()
@@ -61,7 +60,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'member', 'data-thing');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<select data-thing id="Test" class="form-control" name="test"><option value="admin" >Admin</option><option value="member" selected>Member</option></select>');
+        $this->assertEquals('<select data-thing id="Test" class="form-control" name="test"><option value="admin" >Admin</option><option value="member" selected>Member</option></select>', $test);
     }
 
     public function testMakeCheckbox()
@@ -72,7 +71,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'selected', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input  id="Test" selected type="checkbox" name="test">');
+        $this->assertEquals('<input  id="Test" selected type="checkbox" name="test">', $test);
     }
 
     public function testMakeRadio()
@@ -83,7 +82,7 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ], 'selected', '');
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input  id="Test" selected type="radio" name="test">');
+        $this->assertEquals('<input  id="Test" selected type="radio" name="test">', $test);
     }
 
     public function testMakeInputString()
@@ -102,6 +101,6 @@ class HtmlGeneratorTest extends PHPUnit_Framework_TestCase
         ]);
 
         $this->assertTrue(is_string($test));
-        $this->assertEquals($test, '<input data-stuff id="Test" class="form-control" type="text" name="test"   value="sample Test" placeholder="wtf">');
+        $this->assertEquals('<input data-stuff id="Test" class="form-control" type="text" name="test"   value="sample Test" placeholder="wtf">', $test);
     }
 }

--- a/tests/InputMakerTest.php
+++ b/tests/InputMakerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Container\Container as Container;
 use Illuminate\Support\Facades\Facade as Facade;
 use Yab\Laracogs\Utilities\InputMaker;


### PR DESCRIPTION
Made the tests somewhat better readable by for instance using assertContains instead of assertTrue(strpos(...) !== false). Also, changed the order of parameters in some cases, so the expected output is the first parameters. Both help in showing more accurate reasons why a test fails.

Also changed the test methods to a sort of 'given when then' format, to improve readability. And restructured the DatabaseGeneratorTest.