### PR TITLE
Removed recursion in User::isTeamMember

### DIFF
--- a/src/Packages/Starter/app/Models/User.php
+++ b/src/Packages/Starter/app/Models/User.php
@@ -95,13 +95,9 @@ class User extends Model implements
      */
     public function isTeamMember($id)
     {
-        $teamIds = [];
-
-        foreach ($this->teams->toArray() as $team) {
-            $teamIds[] = $team['id'];
-        }
-
-        return in_array($id, $teamIds);
+       return array_search($id, 
+                           array_column($this->teams->toArray(), 'id')
+                          ) > -1;
     }
 
     /**


### PR DESCRIPTION
You can skip the iteration because the execution time increases quickly when there are many teams. Also, pushing to "$teamIds[] = $team['id'];" within the loop, adds unnecessary mem allocation overheads.