### PR TITLE
Allow isTeamAdmin to be called on all teams, not just teams the users…

### DIFF
--- a/src/Packages/Starter/app/Models/User.php
+++ b/src/Packages/Starter/app/Models/User.php
@@ -95,7 +95,11 @@ class User extends Authenticatable
     public function isTeamAdmin($id)
     {
         $team = $this->teams->find($id);
-        return (int) $team->user_id === (int) $this->id;
+        if($team){
+		return (int) $team->user_id === (int) $this->id;
+	}else{
+		return false;
+	}
     }
 
     /**


### PR DESCRIPTION
Allow isTeamAdmin to be called on all teams, not just teams the users is associated with

Not too sure if you want this but, came across an issue when checking if a user is team admin on a team they are not associated with.

This fix allows  isTeamAdmin to be called on all teams