### PR TITLE
Add missing comma in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ composer require "yab/laracogs"
 
 Add this to the `config/app.php` in the providers array:
 ```php
-Yab\Laracogs\LaracogsProvider::class
+Yab\Laracogs\LaracogsProvider::class,
 ```
 
 ##### After these few steps you have the following tools at your fingertips:


### PR DESCRIPTION
Technically there should be a comma after adding the provider to the providers array. Including the comma makes the set up more copy/paste friendly ;)