### PR TITLE
Billing form needs more specificity to not get triggered multiple times

### DIFF
--- a/src/Packages/Billing/resources/assets/js/subscription.js
+++ b/src/Packages/Billing/resources/assets/js/subscription.js
@@ -1,5 +1,5 @@
 $(function(){
-    $('form').card({
+    $('form.billing').card({
         form: 'form',
         container: '.card-wrapper',
         placeholders: {
@@ -15,7 +15,7 @@ $(function(){
             'backface-visibility': 'hidden'
         });
 
-        $('form').submit(function(event) {
+        $('form.billing').submit(function(event) {
             var $form = $(this);
             $form.find('button').prop('disabled', true);
 
@@ -32,7 +32,7 @@ $(function(){
     });
 
     var stripeResponseHandler = function(status, response) {
-        var $form = $('form');
+        var $form = $('form.billing');
 
         if (response.error) {
             $form.find('.payment-errors').text(response.error.message);

--- a/src/Packages/Billing/resources/views/billing/subscribe.blade.php
+++ b/src/Packages/Billing/resources/views/billing/subscribe.blade.php
@@ -17,7 +17,7 @@
             </div>
 
             <div class="col-md-6 col-md-offset-3 raw-margin-top-24 well">
-                <form method="POST" action="/user/billing/subscribe">
+                <form method="POST" class="billing" action="/user/billing/subscribe">
 
                     @include('billing.card-form')
 


### PR DESCRIPTION
Credit card shows multiple times when page includes any other form ,search bar, debugbar, etc.... And any other form submission will trigger Stripe, even if it isn't the billing form.