### PR TITLE
Removing credit card input name for security

### DIFF
--- a/src/Packages/Billing/resources/views/billing/card-form.blade.php
+++ b/src/Packages/Billing/resources/views/billing/card-form.blade.php
@@ -1,16 +1,16 @@
 {!! csrf_field() !!}
 
-<input type="hidden" id="exp_month" name="exp_month" data-stripe="exp-month">
-<input type="hidden" id="exp_year" name="exp_year" data-stripe="exp-year">
+<input type="hidden" id="exp_month" data-stripe="exp-month">
+<input type="hidden" id="exp_year" data-stripe="exp-year">
 
 <div class="form-group number">
     <label for="number">Number</label>
-    <input class="form-control" type="text" name="number" id="number" required placeholder="Card Number" value="{{ old('number') }}" data-stripe="number">
+    <input class="form-control" type="text" id="number" required placeholder="Card Number" value="{{ old('number') }}" data-stripe="number">
 </div>
 
 <div class="form-group name">
     <label for="name">Name</label>
-    <input class="form-control" type="text" name="name" id="name" required placeholder="Full Name" value="{{ $user->name }}" data-stripe="name">
+    <input class="form-control" type="text" id="name" required placeholder="Full Name" value="{{ $user->name }}" data-stripe="name">
 </div>
 
 <div class="form-group expiry">
@@ -20,5 +20,5 @@
 
 <div class="form-group cvc">
     <label for="cvc">CVC</label>
-    <input class="form-control" type="text" name="cvc" id="cvc" required placeholder="CVC" value="{{ old('cvc') }}" data-stripe="cvc">
+    <input class="form-control" type="text" id="cvc" required placeholder="CVC" value="{{ old('cvc') }}" data-stripe="cvc">
 </div>


### PR DESCRIPTION
Stripe.js documentation specifically stipulates for PCI compliance that the application NOT send the plain credit card number to the backend (PHP) (and other sensitive credit card information, such as the CVC and expiration month/year), by removing the name= attributes in the form. See:

https://stripe.com/docs/stripe.js/switching