### PR TITLE
Fix data type issue causing foreignkey constraint

### DIFF
--- a/src/Packages/Starter/database/migrations/2015_11_30_191713_create_user_meta_table.php
+++ b/src/Packages/Starter/database/migrations/2015_11_30_191713_create_user_meta_table.php
@@ -13,7 +13,7 @@ class CreateUserMetaTable extends Migration
     public function up()
     {
         Schema::create('user_meta', function (Blueprint $table) {
-            $table->increments('id');
+            $table->BigIncrements('id');
 
             $table->integer('user_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');


### PR DESCRIPTION
Laravel 5.7 create_users_table migration file comes with BigIncrement for the user ID while the grafite starter pack is just increment for Create_user_meta_table hence users encounter foreign key constraint error during migrate --seed.

Illuminate\Database\QueryException  : SQLSTATE[HY000]: Ge
neral error: 1215 Cannot add foreign key constraint (SQL: alter table `user_meta
` add constraint `user_meta_user_id_foreign` foreign key (`user_id`) references
`users` (`id`) on delete cascade)

The latest version of Laravel 5.8 is just increment but Grafite/Starter does not work properly with it.